### PR TITLE
User message history

### DIFF
--- a/slack2csv/slack2csv.py
+++ b/slack2csv/slack2csv.py
@@ -147,6 +147,7 @@ def main():
 
     count = 0
     last_timestamp = 0
+    header = []
 
     for msg in fetch_from_slack(args.token, conversation_id, time_diff):
 
@@ -158,26 +159,25 @@ def main():
         if msg.get('subtype') != 'bot_message':
             msgUser = msg.get('user')
 
-            msg.setdefault('subtype', '')
+            if 'subtype' in msg:
+                del msg['subtype']
 
             if msgUser != None and msgText.find(args.text) == 0:
 
                 # Write the header if first row
                 if count == 0:
-
-                    header = msg.keys()
-
-                    del msg['subtype']
+                    header = sorted(msg.keys())
 
                     csvwriter.writerow(header)
 
                     count += 1
 
                 last_timestamp = datetime.fromtimestamp(
-                    int(msg.get('ts').split('.')[0]))
+                    float(msg.get('ts')))
 
                 # write the csv row
-                csvwriter.writerow(msg.values())
+                row = [msg.get(k) for k in header]
+                csvwriter.writerow(row)
 
     csv_file.close()
 

--- a/slack2csv/slack2csv.py
+++ b/slack2csv/slack2csv.py
@@ -8,15 +8,35 @@ import requests
 import time
 
 
+QUERY_API_TIMEOUT = 2
+
+
+def paged_query(url):
+    query_url = url
+    next_cursor = True
+    while next_cursor:
+        r = requests.get(query_url)
+        resp = r.json()
+
+        yield resp
+
+        next_cursor = resp.get("response_metadata", {}).get("next_cursor", None)
+        if next_cursor:
+            query_url = url + "&cursor=" + next_cursor
+        else:
+            break
+        time.sleep(QUERY_API_TIMEOUT)
+
+
 def lookup_user_id_by_name(token, user_name):
-    r = requests.get("https://slack.com/api/users.list?token=" +
-                     token)
+    url = "https://slack.com/api/users.list?token=" + token
+    for user_resp in paged_query(url):
 
-    user_list_parsed = r.json()["members"]
+        user_list_parsed = user_resp["members"]
 
-    for user in user_list_parsed:
-        if user["name"] == user_name:
-            return user["id"]
+        for user in user_list_parsed:
+            if user["name"] == user_name:
+                return user["id"]
 
     return ""
 
@@ -25,63 +45,48 @@ def lookup_channel_id_by_name(token, channel_name, types=None):
     url = "https://slack.com/api/conversations.list?token=" + token
     if types is not None:
         url += "&types=" + types
-    query_url = url
+    for channel_resp in paged_query(url):
 
-    channel_list_parsed = [None]
-    while len(channel_list_parsed) > 0:
-        r = requests.get(query_url)
-        resp = r.json()
-
-        channel_list_parsed = resp["channels"]
+        channel_list_parsed = channel_resp["channels"]
 
         for channel in channel_list_parsed:
-            if channel_name in channel.get("name", channel.get("user", None)):
+            if channel_name == channel.get("name", channel.get("user", None)):
                 return channel["id"]
-
-        next_cursor = resp.get("response_metadata", {}).get("next_cursor", None)
-        if next_cursor:
-            query_url = url + "&cursor=" + next_cursor
-        else:
-            break
 
     return ""
 
 
-def fetch_from_slack(token, channel, offset):
-    results = []
-    newest_timestamp = offset
-    more_results = True
-
+def fetch_from_slack(token, channel, oldest):
+    n_messages = 0
+    newest = None
+    oldest = float(oldest)
+    oldest_ts = str(datetime.fromtimestamp(oldest))
     spinner = Spinner('Fetching history for ' +
-                      channel + ' from ' + str(datetime.fromtimestamp(int(offset))) + ' ')
+                      channel + ' from ' + oldest_ts + ' ')
 
-    while more_results == True:
-        print(str(datetime.fromtimestamp(float(newest_timestamp))))
-        r = requests.get("https://slack.com/api/conversations.history?token=" +
-                         token + "&channel=" + channel + "&count=100&inclusive=true&oldest=" + newest_timestamp)
-
-        channel_parsed = r.json()
-
-        if not channel_parsed['ok']:
+    url = ("https://slack.com/api/conversations.history?token=" + token +
+           "&channel=" + channel +
+           "&count=100&inclusive=true&oldest=" + str(round(oldest)))
+    # records are paged oldest to newest, however the message order
+    # within a single response is newest to oldest
+    for message_resp in paged_query(url):
+        if not message_resp['ok']:
             raise ValueError("Error fetching channel history from Slack: ",
-                             channel_parsed["error"])
+                             message_resp["error"])
+        messages = message_resp['messages']
+        newest = messages[0].get('ts', time.time())
+        n_messages += len(messages)
 
-        more_results = channel_parsed["has_more"]
-
-        message_data = channel_parsed['messages']
-
-        # yield interim results
-        for message in message_data:
+        for message in reversed(messages):
             yield message
-
-        newest_timestamp = message_data[0].get('ts')
-
-        time.sleep(2)
         spinner.next()
+    print("\nFetched {0} total messages from {1} to {2}".format(
+                n_messages,
+                oldest_ts,
+                str(datetime.fromtimestamp(float(newest)))))
 
 
 def main():
-
     parser = argparse.ArgumentParser(description='slack2csv')
     parser.add_argument('--text', help='text to search for', default='')
     parser.add_argument(
@@ -129,8 +134,8 @@ def main():
         print("Could not find a valid conversation id. Exiting...")
         return False
 
-    time_diff = str((datetime.now() - timedelta(days=int(args.past_days))
-                     ).timestamp()).split('.')[0]
+    time_diff = time.mktime((datetime.now() -
+                             timedelta(days=int(args.past_days))).timetuple())
 
     # open a file for writing
 

--- a/slack2csv/tests/test_slack2csv.py
+++ b/slack2csv/tests/test_slack2csv.py
@@ -4,7 +4,11 @@ import pytest
 from mock import Mock, patch
 
 # Local imports...
-from slack2csv.slack2csv import fetch_from_slack, lookup_channel_id_by_name
+import slack2csv.slack2csv
+from slack2csv.slack2csv import fetch_from_slack, lookup_channel_id_by_name, lookup_user_id_by_name
+
+# turn down the timeout, so the tests run faster
+slack2csv.slack2csv.QUERY_API_TIMEOUT = 0
 
 
 @patch('slack2csv.slack2csv.requests.get')
@@ -56,6 +60,44 @@ def test_lookup_channel_id_by_name_fail(mock_get):
 
 
 @patch('slack2csv.slack2csv.requests.get')
+def test_lookup_channel_id_by_name_paged(mock_get):
+    true = 1
+    false = 0
+    fake_response = [{
+        "ok": true,
+        "channels": [{
+            "id": "C8675310",
+            "name": "johnny",
+        }],
+        "response_metadata": {"next_cursor": "foo"}
+    },{
+        "ok": true,
+        "channels": [{
+            "id": "C8675319",
+            "name": "carl",
+        }],
+        "response_metadata": {"next_cursor": "bar"}
+    },{
+        "ok": true,
+        "channels": [{
+            "id": "C8675309",
+            "name": "jenny",
+        }]
+    }]
+
+    mock_get.return_value.json.side_effect = fake_response
+
+    # Configure the mock to return a response with an OK status code.
+    mock_get.return_value.ok = True
+
+    # Call the service, which will send a request to the server.
+    messages = lookup_channel_id_by_name('a', 'jenny')
+
+    # If the request is sent successfully, then I expect a response to be returned.
+    assert(messages == "C8675309")
+
+
+@patch('slack2csv.slack2csv.requests.get')
 def test_fetch_from_slack_success(mock_get):
     true = 1
     false = 0
@@ -76,7 +118,7 @@ def test_fetch_from_slack_success(mock_get):
     mock_get.return_value.ok = True
 
     # Call the service, which will send a request to the server.
-    messages = fetch_from_slack('a', 'b', '1')
+    messages = list(fetch_from_slack('a', 'b', '1'))
 
     # If the request is sent successfully, then I expect a response to be returned.
     assert(len(messages) == 1)
@@ -106,6 +148,144 @@ def test_fetch_from_slack_fail(mock_get):
 
     # Call the service, which will send a request to the server.
     with pytest.raises(ValueError) as exc_info:
-        messages = fetch_from_slack('a', 'b', '1')
+        messages = list(fetch_from_slack('a', 'b', '1'))
 
     assert "I'm an error" in str(exc_info.value)
+
+
+@patch('slack2csv.slack2csv.requests.get')
+def test_fetch_from_slack_paged(mock_get):
+    true = 1
+    false = 0
+    fake_response = {
+        "ok": true,
+        "has_more": false,
+        "messages": [{
+            "type": "message",
+            "user": "U0012345",
+            "text": "Hey!",
+            "ts": "1513173325.000024"
+        }],
+        "response_metadata": {"next_cursor": "foo"}
+    },{
+        "ok": true,
+        "has_more": false,
+        "messages": [{
+            "type": "message",
+            "user": "U0012345",
+            "text": "Hey!",
+            "ts": "1513173325.000024"
+        }],
+        "response_metadata": {"next_cursor": "bar"}
+    },{
+        "ok": true,
+        "has_more": false,
+        "messages": [{
+            "type": "message",
+            "user": "U0012345",
+            "text": "Hey!",
+            "ts": "1513173325.000024"
+        }],
+    }
+
+    mock_get.return_value.json.side_effect = fake_response
+
+    # Configure the mock to return a response with an OK status code.
+    mock_get.return_value.ok = True
+
+    # Call the service, which will send a request to the server.
+    messages = list(fetch_from_slack('a', 'b', '1'))
+
+    # If the request is sent successfully, then I expect a response to be returned.
+    assert(len(messages) == 3)
+
+
+@patch('slack2csv.slack2csv.requests.get')
+def test_lookup_user_id_by_name_success(mock_get):
+    true = 1
+    false = 0
+    fake_response = {
+        "ok": true,
+        "members": [{
+            "id": "U5NQQHZ11",
+            "name": "alice",
+            "real_name": "Alice Smith",
+        }]
+    }
+
+    mock_get.return_value.json.return_value = fake_response
+
+    # Configure the mock to return a response with an OK status code.
+    mock_get.return_value.ok = True
+
+    # Call the service, which will send a request to the server.
+    user_id = lookup_user_id_by_name('a', 'alice')
+
+    # If the request is sent successfully, then I expect a response to be returned.
+    assert(user_id == "U5NQQHZ11")
+
+
+@patch('slack2csv.slack2csv.requests.get')
+def test_lookup_user_id_by_name_fail(mock_get):
+    true = 1
+    false = 0
+    fake_response = {
+        "ok": true,
+        "members": [{
+            "id": "U5NQQHZ11",
+            "name": "alice",
+            "real_name": "Alice Smith",
+        }]
+    }
+
+    mock_get.return_value.json.return_value = fake_response
+
+    # Configure the mock to return a response with an OK status code.
+    mock_get.return_value.ok = True
+
+    # Call the service, which will send a request to the server.
+    user_id = lookup_user_id_by_name('a', 'jenny')
+
+    # If the request is sent successfully, then I expect a response to be returned.
+    assert(user_id == "")
+
+
+@patch('slack2csv.slack2csv.requests.get')
+def test_lookup_user_id_by_name_paged(mock_get):
+    true = 1
+    false = 0
+    fake_response = {
+        "ok": true,
+        "members": [{
+            "id": "U5NQQHZ1X",
+            "name": "larry",
+            "real_name": "Larry Nash",
+        }],
+        "response_metadata": {"next_cursor": "foo"}
+    },{
+        "ok": true,
+        "members": [{
+            "id": "U5NQQHZ12",
+            "name": "jane",
+            "real_name": "Jane Johnson",
+        }],
+        "response_metadata": {"next_cursor": "foo"}
+    },{
+        "ok": true,
+        "members": [{
+            "id": "U5NQQHZ11",
+            "name": "alice",
+            "real_name": "Alice Smith",
+        }]
+    }
+
+    mock_get.return_value.json.side_effect = fake_response
+
+    # Configure the mock to return a response with an OK status code.
+    mock_get.return_value.ok = True
+
+    # Call the service, which will send a request to the server.
+    user_id = lookup_user_id_by_name('a', 'alice')
+
+    # If the request is sent successfully, then I expect a response to be returned.
+    assert(user_id == "U5NQQHZ11")


### PR DESCRIPTION
**New feature: download private message history**

Improvements:
  * paginated lookup for users and channels (good for large workspace)
  * use conversations API instead of channel for retrieving message history
  * refactor message fetching loop for simplicity: let the slack API server do the pagination
  * fetch_from_slack is now a generator that yields each message as it is retrieved. this allows the csv file to be written on the fly. user or network disruption during a long fetch process can be resumed, since partial data is written to the file with a timestamp
  * fix for csv output: write the field in the same order for each row

* minor fix for python 2.7 compatability
* test cases added for new functionality

```
(venv) root@420fcc8fe599:/git/slack2csv# pytest -v
======================================================================== test session starts ========================================================================
platform linux -- Python 3.5.2, pytest-4.1.1, py-1.7.0, pluggy-0.8.1 -- /git/slack2csv/venv/bin/python3.5
cachedir: .pytest_cache
rootdir: /git/slack2csv, inifile:
collected 9 items                                                                                                                                                   

slack2csv/tests/test_slack2csv.py::test_lookup_channel_id_by_name_success PASSED                                                                              [ 11%]
slack2csv/tests/test_slack2csv.py::test_lookup_channel_id_by_name_fail PASSED                                                                                 [ 22%]
slack2csv/tests/test_slack2csv.py::test_lookup_channel_id_by_name_paged PASSED                                                                                [ 33%]
slack2csv/tests/test_slack2csv.py::test_fetch_from_slack_success PASSED                                                                                       [ 44%]
slack2csv/tests/test_slack2csv.py::test_fetch_from_slack_fail PASSED                                                                                          [ 55%]
slack2csv/tests/test_slack2csv.py::test_fetch_from_slack_paged PASSED                                                                                         [ 66%]
slack2csv/tests/test_slack2csv.py::test_lookup_user_id_by_name_success PASSED                                                                                 [ 77%]
slack2csv/tests/test_slack2csv.py::test_lookup_user_id_by_name_fail PASSED                                                                                    [ 88%]
slack2csv/tests/test_slack2csv.py::test_lookup_user_id_by_name_paged PASSED                                                                                   [100%]

===================================================================== 9 passed in 0.14 seconds =====================================================================
```

```
(venv27) root@420fcc8fe599:/git/slack2csv# pytest -v
======================================================================== test session starts ========================================================================
platform linux2 -- Python 2.7.12, pytest-4.1.1, py-1.7.0, pluggy-0.8.1 -- /git/slack2csv/venv27/bin/python
cachedir: .pytest_cache
rootdir: /git/slack2csv, inifile:
collected 9 items                                                                                                                                                   

slack2csv/tests/test_slack2csv.py::test_lookup_channel_id_by_name_success PASSED                                                                              [ 11%]
slack2csv/tests/test_slack2csv.py::test_lookup_channel_id_by_name_fail PASSED                                                                                 [ 22%]
slack2csv/tests/test_slack2csv.py::test_lookup_channel_id_by_name_paged PASSED                                                                                [ 33%]
slack2csv/tests/test_slack2csv.py::test_fetch_from_slack_success PASSED                                                                                       [ 44%]
slack2csv/tests/test_slack2csv.py::test_fetch_from_slack_fail PASSED                                                                                          [ 55%]
slack2csv/tests/test_slack2csv.py::test_fetch_from_slack_paged PASSED                                                                                         [ 66%]
slack2csv/tests/test_slack2csv.py::test_lookup_user_id_by_name_success PASSED                                                                                 [ 77%]
slack2csv/tests/test_slack2csv.py::test_lookup_user_id_by_name_fail PASSED                                                                                    [ 88%]
slack2csv/tests/test_slack2csv.py::test_lookup_user_id_by_name_paged PASSED                                                                                   [100%]

===================================================================== 9 passed in 0.10 seconds =====================================================================
```